### PR TITLE
Put queries into a global queue rather than keep a separate list of queries per thread

### DIFF
--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -5,7 +5,6 @@ from Queue import Queue, Empty, Full
 _local = threading.local()
 _queue = Queue(maxsize=500)
 
-# _local = threading.local()
 _engines = {}
 
 class QueryStats:


### PR DESCRIPTION
This means generating a report shows queries from all threads, not just the one from the thread that called collect().
