### PR TITLE
fix urlparse import for python3

### DIFF
--- a/sqltap/wsgi.py
+++ b/sqltap/wsgi.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
-import urlparse
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
 from . import sqltap
 try:
     import queue

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -3,8 +3,11 @@ from __future__ import print_function
 from sqlalchemy import *
 from sqlalchemy.orm import *
 from sqlalchemy.ext.declarative import declarative_base
-import sqltap, unittest
 import nose.tools
+
+import sqltap
+import sqltap.wsgi
+
 
 def _startswith(qs, text):
     return list(filter(lambda q: str(q.text).startswith(text), qs))
@@ -275,3 +278,7 @@ class TestSQLTap(object):
         def noop(): pass
         profiler = sqltap.start(self.engine, collect_fn=noop)
         profiler.collect()
+
+    def test_can_construct_wsgi_wrapper(self):
+        """Only verifies that the imports and __init__ work, not a real Test."""
+        sqltap.wsgi.SQLTapMiddleware(app=None)


### PR DESCRIPTION
I missed an import last time. I included the wsgi module in the unittest, but only "test" the constructor, I did not write actual tests for anythin.

Actually this (urlparse, queue etc.) is something that setuptools should be able to fix by itself with 2to3, but I could not get it to work: https://pythonhosted.org/setuptools/python3.html
