### PR TITLE
Escape HTML characters in stacktraces to prevent the layout and formatting from breaking.

### DIFF
--- a/sqltap/templates/report.mako
+++ b/sqltap/templates/report.mako
@@ -122,7 +122,7 @@ ${group.first_word}
                       <strong>${fr[2]}</strong> @${fr[0].split()[-1]}:${fr[1]}
                       </h5>
                     </a>
-                    <pre class="trace hidden">${trace}</pre>
+                    <pre class="trace hidden">${trace|h}</pre>
                   </li>
                   % endfor
               </ul>


### PR DESCRIPTION
If a stacktrace in a report contains a line like

``` pytb
  File "<string>", line 1, in <lambda>
```

then the strings in angle brackets will be interpreted as HTML tags and break the formatting,

Escaping HTML characters in the stacktraces fixes the issue for me. A patch is attached.
