### PR TITLE
Display query parameters in the report.

### DIFF
--- a/sqltap/templates/report.mako
+++ b/sqltap/templates/report.mako
@@ -99,6 +99,17 @@ ${group.first_word}
 
               <hr />
               <pre><code>${group.text}</code></pre>
+              <hr />
+
+              <h4>Params</h4>
+              % for query_index, query in enumerate(group.queries):
+              <h5>Query ${query_index}:</h5>
+              <pre><code>
+                % for param_key, param_value in query.text.params.iteritems():
+                    ${param_key}: ${param_value}
+                % endfor
+              </code></pre>
+              % endfor
 
               <hr />
               <% stack_count = len(group.stacks) %>


### PR DESCRIPTION
I wanted to be able to see the parameters used for the individual queries. Below is a sample of what it looks like.

![sqltap_screenshot](https://cloud.githubusercontent.com/assets/742633/5480389/0862f92c-8603-11e4-80b2-9b27128f3416.png)
