### PR TITLE
Fixed AttributeError when using raw SQL

### DIFF
--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -32,6 +32,7 @@ class QueryStats(object):
     """
     def __init__(self, text, stack, duration, user_context):
         self.text = text
+        self.params = getattr(text, 'params', {})
         self.stack = stack
         self.duration = duration
         self.user_context = user_context

--- a/sqltap/templates/report.mako
+++ b/sqltap/templates/report.mako
@@ -102,7 +102,7 @@ ${group.first_word}
               <hr />
 
               <%
-                params = group.queries[0].text.params.keys()
+                params = group.queries[0].params.keys()
               %>
               <h4>
                 Query Breakdown

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -146,6 +146,17 @@ class TestSQLTap(object):
         assert 'sqltap profile report' in report
         assert qtext in report
 
+    def test_report_raw_sql(self):
+        """ Ensure that reporting works when raw SQL queries were emitted. """
+        profiler = sqltap.start(self.engine)
+
+        sess = self.Session()
+        sql = 'SELECT * FROM %s' % self.A.__tablename__
+        sess.connection().execute(sql)
+
+        report = sqltap.report(profiler.collect())
+        assert 'sqltap profile report' in report
+        assert sql in report
 
     def test_report_aggregation(self):
         """


### PR DESCRIPTION
When executing raw SQL in my application, the report generation would
fail:

```python
Traceback (most recent call last):
  File "utils/profiling.py", line 62, in __exit__
    sqltap.report(stats, self.report_path)
  File "venv/lib/python2.7/site-packages/sqltap/sqltap.py", line 302, in report
    **kwargs
  File "venv/lib/python2.7/site-packages/mako/template.py", line 443, in render
    return runtime._render(self, self.callable_, args, data)
  File "venv/lib/python2.7/site-packages/mako/runtime.py", line 803, in _render
    **_kwargs_for_callable(callable_, data))
  File "venv/lib/python2.7/site-packages/mako/runtime.py", line 835, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "venv/lib/python2.7/site-packages/mako/runtime.py", line 860, in _exec_template
    callable_(context, *args, **kwargs)
  File "report_mako", line 68, in render_body
AttributeError: 'str' object has no attribute 'params'
```


This was because the default report template uses `text.params`;
this attribute does not exist if the `text` passed to `QueryStats` is a
plain string (which it is when doing raw queries).

This fix introduces the `params` attribute for `QueryStats` objects and adjusts the Mako template to use it. `params` is an empty dict if the `text` passed in is a plain string.

Please merge it if you like and push a new version to PyPI.