### PR TITLE
Handle dynamically started profiling on multiple threads; improve reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ SQLTap is hosted on github at: https://github.com/inconshreveable/sqltap
 
 setup(
     name = "sqltap",
-    version = "0.3.8",
+    version = "0.3.8.1",
     description = "Profiling and introspection for applications using sqlalchemy",
     long_description = long_description,
     author = "inconshreveable",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ SQLTap is hosted on github at: https://github.com/inconshreveable/sqltap
 
 setup(
     name = "sqltap",
-    version = "0.3.7",
+    version = "0.3.8",
     description = "Profiling and introspection for applications using sqlalchemy",
     long_description = long_description,
     author = "inconshreveable",

--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -37,6 +37,10 @@ class QueryStats(object):
         self.duration = duration
         self.user_context = user_context
 
+    def __repr__(self):
+        return "<%s text=%r params=%r duration=%f>" % (
+            self.__class__.__name__, self.text, self.params, self.duration)
+
 class ProfilingSession(object):
     """ A ProfilingSession captures queries run on an Engine and metadata about them.
 
@@ -125,7 +129,9 @@ class ProfilingSession(object):
     def _after_exec(self, conn, clause, multiparams, params, results):
         """ SQLAlchemy event hook """
         # calculate the query time
-        duration = time.time() - conn._sqltap_query_start_time
+        end_time = time.time()
+        start_time = getattr(conn, '_sqltap_query_start_time', end_time)
+        duration = end_time - start_time
 
         # get the user's context
         context = (None if not self.user_context_fn else

--- a/sqltap/templates/report.mako
+++ b/sqltap/templates/report.mako
@@ -13,7 +13,7 @@
     <link href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- syntax highlighting -->
-    <link rel="stylesheet" href="http://yandex.st/highlightjs/8.0/styles/default.min.css">
+    <link href="http://yandex.st/highlightjs/8.0/styles/default.min.css" rel="stylesheet">
     <script src="http://yandex.st/highlightjs/8.0/highlight.min.js"></script>
     <style type="text/css">
       body { padding-top: 60px; }
@@ -154,6 +154,9 @@ ${group.first_word}
                   % endfor
               </ul>
             </div>
+
+            <!-- ================================================== -->
+
             % endfor
           </div>
         </div>

--- a/sqltap/templates/report.mako
+++ b/sqltap/templates/report.mako
@@ -10,7 +10,7 @@
     <title>sqltap profile report</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- syntax highlighting -->
     <link rel="stylesheet" href="http://yandex.st/highlightjs/8.0/styles/default.min.css">
@@ -160,9 +160,9 @@ ${group.first_word}
     </div><!-- /.container -->
 
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         jQuery(function($) {

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -116,8 +116,11 @@ class TestSQLTap(object):
         profiler.start()
         try:
             profiler.start()
+            raise ValueError("Second start should have asserted")
         except AssertionError:
             pass
+        except:
+            assert False, "Got some non-assertion exception"
         profiler.stop()
 
     def test_stop(self):


### PR DESCRIPTION
If SQLTap is started dynamically on one thread, any SQLAlchemy sessions running on other threads start being profiled. Their connections did not receive the `before_execute` event, so when they receive the `after_execute` event, extra care must be taken.

Also, make reports work properly when loaded from local filesystem, `file://`