### PR TITLE
Fix ProfilingSession.__enter__

### DIFF
--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -191,6 +191,7 @@ class ProfilingSession(object):
     def __enter__(self, *args, **kwargs):
         """ context manager """
         self.start()
+        return self
 
     def __exit__(self, *args, **kwargs):
         """ context manager """


### PR DESCRIPTION
`__enter__` should return `self`. Otherwise:

```
   with ProfilingSession() as profiler:
       assert profiler is not None
```

fails.