### PR TITLE
Fix UnicodeDecodeError in python2.7

### DIFF
--- a/sqltap/templates/html.mako
+++ b/sqltap/templates/html.mako
@@ -149,7 +149,7 @@ ${group.first_word}
                       <strong>${fr[2]}</strong> @${fr[0].split()[-1]}:${fr[1]}
                       </h5>
                     </a>
-                    <pre class="trace hidden">${trace}</pre>
+                    <pre class="trace hidden">${trace.decode('utf-8')}</pre>
                   </li>
                   % endfor
               </ul>


### PR DESCRIPTION
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xec in position 5503: ordinal not in range(128)` occures in `html.mako`  when`trace` is a `str` that contain character which ascii can't decode .