### PR TITLE
Fixed failing reports with groups having different param sets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ SQLTap is hosted on github at: https://github.com/inconshreveable/sqltap
 
 setup(
     name="sqltap",
-    version="0.3.10",
+    version="0.3.11",
     description=("Profiling and introspection for applications using "
                  "sqlalchemy"),
     long_description=long_description,

--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -329,7 +329,10 @@ class QueryGroup(object):
             self.median = queries[length // 2].duration
 
     def get_param_names(self):
-        """Aggregate param names from all queries in the group and return as an ordered list."""
+        """
+        Aggregate param names from all queries in the group
+        and return as an ordered list.
+        """
         names = set()
         for query in self.queries:
             names |= set(query.params.keys())

--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -328,6 +328,14 @@ class QueryGroup(object):
         else:
             self.median = queries[length // 2].duration
 
+    def get_param_names(self):
+        """Aggregate param names from all queries in the group and return as an ordered list."""
+        names = set()
+        for query in self.queries:
+            names |= set(query.params.keys())
+
+        return sorted(list(names))
+
 
 class Reporter(object):
     """ An SQLTap Reporter base class """

--- a/sqltap/templates/html.mako
+++ b/sqltap/templates/html.mako
@@ -124,7 +124,7 @@ ${group.first_word}
               <hr />
 
               <%
-                params = group.queries[0].params.keys()
+                params = group.get_param_names()
               %>
               <h4>
                 Query Breakdown
@@ -142,7 +142,7 @@ ${group.first_word}
                 <tr class="${'hidden' if idx >= 3 else ''}">
                     <td>${'%.3f' % query.duration}</td>
                     % for param_name in params:
-                    <td>${query.params[param_name]}</td>
+                    <td>${query.params.get(param_name, '')}</td>
                     % endfor
                     <td>${'%d' % query.rowcount}</td>
                     <td>${'%d' % query.params_id}</td>

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -348,7 +348,8 @@ class TestSQLTap(object):
 
     def test_report_aggregation_w_different_param_sets(self):
         """
-        Test that report rendering works with groups of queries containing different parameter sets
+        Test that report rendering works with groups of queries
+        containing different parameter sets
         """
 
         sess = self.Session()

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import os
 import tempfile
 import collections
+import uuid
 
 from sqlalchemy import *  # noqa
 from sqlalchemy.orm import *  # noqa
@@ -41,11 +42,20 @@ class TestSQLTap(object):
             __tablename__ = "a"
             id = Column("id", Integer, primary_key=True)
             name = Column("name", String)
+            description = Column("description", String)
         self.A = A
 
         Base.metadata.create_all(self.engine)
 
         self.Session = sessionmaker(bind=self.engine)
+
+    def check_report(self, report):
+        """
+        Check whether the SQL report was actually rendered.
+        If the report fails, then a Mako error report is generated instead
+        with `Mako Runtime Error` in its title.
+        """
+        assert REPORT_TITLE in report
 
     def assertEqual(self, expected, actual, message=None):
         message = message or "{0!r} == {1!r}".format(expected, actual)
@@ -335,6 +345,33 @@ class TestSQLTap(object):
         assert '2 unique' in report
         assert '<dd>10</dd>' in report
         profiler.stop()
+
+    def test_report_aggregation_w_different_param_sets(self):
+        """
+        Test that report rendering works with groups of queries containing different parameter sets
+        """
+
+        sess = self.Session()
+
+        a1 = self.A(name=uuid.uuid4().hex, description='')
+        a2 = self.A(name=uuid.uuid4().hex, description='')
+        sess.add_all([a1, a2])
+        sess.commit()
+
+        a1 = sess.query(self.A).get(a1.id)
+        a2 = sess.query(self.A).get(a2.id)
+
+        profiler = sqltap.start(self.engine)
+        # this will create queries with the same text, but different param sets
+        # (different query.params.keys() collections)
+        a1.name = uuid.uuid4().hex
+        a2.description = uuid.uuid4().hex
+        sess.flush()
+
+        report = sqltap.report(profiler.collect())
+        print(report)
+        profiler.stop()
+        self.check_report(report)
 
     def test_start_stop(self):
         sess = self.Session()


### PR DESCRIPTION
I also have a question: why not actually use `unittest.TestCase` for tests?