### PR TITLE
Fix SQLAlchemy 1.4 deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-install:
-  - python setup.py develop
-  - pip install flake8
-script:
-  - flake8 --ignore=H302,H306,H402,H404,H405,H904,E126,E128,C901,F405
-           --show-source
-           --builtins=_
-           --max-line-length=79
-           --exclude=.venv,.git,.tox,dist,doc,.eggs,*.egg-info
-  - python setup.py test
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+install: tox-travis
+script: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.isort]
+profile = 'black'
+multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -28,21 +28,16 @@ setup(
     packages=["sqltap"],
     package_data={"sqltap": ["templates/*.mako"]},
     install_requires=[
-        "SQLAlchemy >= 0.9",
+        "SQLAlchemy >= 1.4",
         "Mako >= 0.4.1",
         "Werkzeug >= 0.9.6",
         "sqlparse >= 0.1.15"
     ],
-    tests_require=[
-        "nose"
-    ],
-    test_suite='nose.collector',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Topic :: Database'
     ]

--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -165,11 +165,11 @@ class ProfilingSession(object):
             self.collector = queue.Queue(0)
             self.collect_fn = self.collector.put
 
-    def _before_exec(self, conn, clause, multiparams, params):
+    def _before_exec(self, conn, clause, multiparams, params, execution_options):
         """ SQLAlchemy event hook """
         conn._sqltap_query_start_time = time.time()
 
-    def _after_exec(self, conn, clause, multiparams, params, results):
+    def _after_exec(self, conn, clause, multiparams, params, execution_options, results):
         """ SQLAlchemy event hook """
         # calculate the query time
         end_time = time.time()

--- a/sqltap/sqltap.py
+++ b/sqltap/sqltap.py
@@ -1,23 +1,23 @@
 from __future__ import division
 
+import collections
 import datetime
+import os
+import sys
 import time
 import traceback
-import collections
-import sys
-import os
+
 try:
     import queue
 except ImportError:
     import Queue as queue
 
 import mako.exceptions
-import mako.template
 import mako.lookup
+import mako.template
 import sqlalchemy.engine
 import sqlalchemy.event
 import sqlparse
-
 
 REPORT_HTML = "html"
 REPORT_WSGI = "wsgi"
@@ -561,8 +561,8 @@ def _hotfix_dispatch_remove():
     if sqlalchemy.__version__ >= "0.9.4":
         return
 
-    from sqlalchemy.event.attr import _DispatchDescriptor
     from sqlalchemy.event import registry
+    from sqlalchemy.event.attr import _DispatchDescriptor
 
     def remove(self, event_key):
         target = event_key.dispatch_target
@@ -575,5 +575,6 @@ def _hotfix_dispatch_remove():
         registry._removed_from_collection(event_key, self)
 
     _DispatchDescriptor.remove = remove
+
 
 _hotfix_dispatch_remove()

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -1,23 +1,22 @@
 # -*- encoding: utf8 -*-
 from __future__ import print_function
 
+import collections
 import os
 import tempfile
-import collections
 import uuid
 
-from sqlalchemy import *  # noqa
-from sqlalchemy.orm import *  # noqa
-from sqlalchemy.ext.declarative import declarative_base
+import nose.tools
 import sqlalchemy.event
 import sqlparse
-import nose.tools
+from sqlalchemy import Column, Integer, String, Unicode, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session, sessionmaker
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
 import sqltap
 import sqltap.wsgi
-
 
 REPORT_TITLE = "SQLTap Profiling Report"
 
@@ -150,8 +149,6 @@ class TestSQLTap(object):
             raise ValueError("Second start should have asserted")
         except AssertionError:
             pass
-        except:
-            assert False, "Got some non-assertion exception"
         profiler.stop()
 
     def test_stop(self):

--- a/tests/test_sqltap.py
+++ b/tests/test_sqltap.py
@@ -5,6 +5,7 @@ import collections
 import os
 import tempfile
 import uuid
+import warnings
 
 import nose.tools
 import sqlalchemy.event
@@ -13,10 +14,12 @@ from sqlalchemy import Column, Integer, String, Unicode, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 from werkzeug.test import Client
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response
 
 import sqltap
 import sqltap.wsgi
+
+warnings.simplefilter(os.environ.get('WARNING_ACTION', 'error'))
 
 REPORT_TITLE = "SQLTap Profiling Report"
 
@@ -522,7 +525,7 @@ class TestSQLTapMiddleware(TestSQLTap):
         super(TestSQLTapMiddleware, self).setUp()
         from werkzeug.testapp import test_app
         self.app = sqltap.wsgi.SQLTapMiddleware(app=test_app)
-        self.client = Client(self.app, BaseResponse)
+        self.client = Client(self.app, Response)
 
     def test_can_construct_wsgi_wrapper(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ deps =
     lowest: werkzeug==0.9.6
     lowest: sqlparse==0.1.15
 commands = nosetests tests
+setenv =
+    # Mako spews ResourceWarnings in 3.6
+    lowest: WARNING_ACTION = always
 
 [testenv:flake8]
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,26 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pep8
+envlist =
+    py{36,37,38,39}
+    py36-lowest
+    flake8
+skip_missing_interpreters = true
 
 [testenv]
 usedevelop = true
-commands = python setup.py test
+deps =
+    nose
+    lowest: mako==0.4.1
+    lowest: sqlalchemy==1.4
+    lowest: werkzeug==0.9.6
+    lowest: sqlparse==0.1.15
+commands = nosetests tests
 
-[testenv:pep8]
+[testenv:flake8]
 commands = flake8
 deps =
-  flake8
+    flake8
 
 [flake8]
 # ignored flake8 codes:
@@ -31,3 +41,7 @@ show-source = true
 builtins = _
 max-line-length = 79
 exclude=.venv,.git,.tox,dist,doc,.eggs,*.egg-info
+
+[travis]
+python =
+  3.9: py39, flake8


### PR DESCRIPTION
And other project tweaks to bring it more up-to-date.

This raises the minimum supported Python version to 3.6 and SQLAlchemy to 1.4.  Should those be documented somewhere?

fixes #46 

Todo:

- [ ] Make sure travis runs all tox envs.  If not, fix `[travis]` section in tox.ini.